### PR TITLE
Add RADIO backbone

### DIFF
--- a/configs/backbone/radio.yaml
+++ b/configs/backbone/radio.yaml
@@ -1,0 +1,3 @@
+_target_: evals.models.radio.RADIO
+version: radio_v2
+output: dense

--- a/evals/models/radio.py
+++ b/evals/models/radio.py
@@ -1,0 +1,103 @@
+"""
+Backbone definition for the RADIO model from:
+
+AM-RADIO: Agglomerative Vision Foundation Model -- Reduce All Domains Into One
+https://arxiv.org/abs/2312.06709
+"""
+import torch
+
+from .utils import center_padding, tokens_to_output
+
+
+class RADIO(torch.nn.Module):
+    """
+    Backbone definition for the RADIO model from.
+
+    Args:
+        version (str): Version of the model to load.
+        output (str): Type of output to return. One of ['dense', 'dense-cls'].
+        return_multilayer (bool): Return features from multiple layers.
+    """
+
+    def __init__(
+        self,
+        version="radio_v2",
+        output="dense",
+        return_multilayer=False,
+    ):
+        super().__init__()
+
+        # Get model from TorchHub.
+        self.version = version
+        self.checkpoint_name = f"{version}"
+        radio = torch.hub.load('NVlabs/RADIO',
+                               'radio_model',
+                               version=self.version,
+                               progress=True,
+                               adaptor_names=None)
+        radio.make_preprocessor_external()
+        self.radio = radio.eval().to(torch.float32)
+
+        assert output in ["dense", "dense-cls"]
+        self.output = output
+
+        patch_gen = radio.model.patch_generator
+        # Cropped Positional Embedding (CPE) case.
+        patch_size = patch_gen.patch_size
+        self.patch_size = patch_size
+
+        feat_dim = radio.model.embed_dim
+        # Double the feature dimension if dense-cls output is requested.
+        feat_dim = feat_dim * 2 if output == "dense-cls" else feat_dim
+
+        # Layers to return activations of in case of "return_multilayer=True".
+        num_layers = len(radio.model.blocks)
+        multilayers = [
+            num_layers // 4 - 1,
+            num_layers // 2 - 1,
+            num_layers // 4 * 3 - 1,
+            num_layers - 1,
+        ]
+
+        if return_multilayer:
+            self.feat_dim = [feat_dim, feat_dim, feat_dim, feat_dim]
+            self.multilayers = multilayers
+        else:
+            self.feat_dim = feat_dim
+            layer = multilayers[-1]
+            self.multilayers = [layer]
+
+        # Define layer name (for logging).
+        self.layer = "-".join(str(_x) for _x in self.multilayers)
+
+    def forward_features(self, x):
+        """Return features from the model."""
+        features = []
+        x = self.radio.model.patch_generator(x)
+
+        for i, blk in enumerate(self.radio.model.blocks):
+            x = blk(x)
+            if i in self.multilayers:
+                # normalize intermediates with final norm layer if enabled
+                features.append(self.radio.model.norm(x))
+
+        return features
+
+    def forward(self, images):
+        """Main forward routine."""
+        # Pad images (if needed) to ensure it matches patch_size.
+        images = center_padding(images, self.patch_size)
+        h, w = images.shape[-2:]
+        h, w = h // self.patch_size, w // self.patch_size
+
+        intermediate_features = self.forward_features(images)
+
+        outputs = []
+        for features in intermediate_features:
+            # Pick the 1st summary token.
+            summary = features[:, 0]
+            patches = features[:, self.radio.model.patch_generator.num_skip :]
+            output = tokens_to_output(self.output, patches, summary, (h, w))
+            outputs.append(output)
+
+        return outputs[0] if len(outputs) == 1 else outputs


### PR DESCRIPTION
This PR adds a backbone definition and associated config file for the RADIO foundation model from:

[CVPR2024] AM-RADIO: Agglomerative Vision Foundation Model -- Reduce All Domains Into One
https://arxiv.org/abs/2312.06709

We measured metrics on the NAVI dataset, and re-ran the DINOv2 baselines for a fair comparison. Below are the corresponding logs files:

Depth estimation:
```
17042024-0541, dinov2_vitb14, 14, 2-5-8-11  , dense-cls , bindepth_dpt_k3,  10, 1.50, 0.0005, 0.0, 8, NAVI_multiview_all_reldepth, NAVI_wild_all_reldepth, 0.4187, 0.6963, 0.8490, 0.1280, 0.5987, 0.8322, 0.9159, 0.0948 
17042024-0612, dinov2_vitl14, 14, 5-11-17-23, dense-cls , bindepth_dpt_k3,  10, 1.50, 0.0005, 0.0, 8, NAVI_multiview_all_reldepth, NAVI_wild_all_reldepth, 0.4537, 0.7297, 0.8654, 0.1213, 0.6302, 0.8499, 0.9242, 0.0887 
17042024-0717, radio_v2     , 16, 7-15-23-31, dense     , bindepth_dpt_k3,  10, 1.50, 0.0005, 0.0, 8, NAVI_multiview_all_reldepth, NAVI_wild_all_reldepth, 0.4894, 0.7631, 0.8894, 0.1117, 0.6391, 0.8580, 0.9309, 0.0859 
```

Surface normals:

```
17042024-1253, radio_v2       , 16, 7-15-23-31, dense     , snorm_dpt_k3_UA,  10, 1.50, 5.00e-04, 0.00e+00,    8, NAVI_multiview_all, NAVI_wild_all, 0.3457, 0.6482, 0.7627, 28.6711 
17042024-1314, dinov2_vitl14  , 14, 5-11-17-23, dense-cls , snorm_dpt_k3_UA,  10, 1.50, 5.00e-04, 0.00e+00,    8, NAVI_multiview_all, NAVI_wild_all, 0.3586, 0.6529, 0.7644, 28.6790 
```

Multi-view correspondance:

```
18042024-0455, dinov2_vitb14, 14, 11   , dense     , 1000, 0.25, NAVI_wild_all, 35.90, 54.25, 82.17,  5.24, 32.32, 49.00, 90.00, 68.82, 51.69, 29.22 
18042024-0503, dinov2_vitl14, 14, 23   , dense     , 1000, 0.25, NAVI_wild_all, 39.28, 57.21, 83.50,  6.05, 35.63, 52.28, 91.60, 72.59, 54.65, 32.15 
18042024-0507, radio_v2     , 16, 31   , dense     , 1000, 0.25, NAVI_wild_all, 40.06, 60.08, 86.12,  4.83, 35.18, 54.65, 91.97, 75.39, 58.26, 35.54 
```
