### PR TITLE
minor interpolation fix

### DIFF
--- a/evals/models/probes.py
+++ b/evals/models/probes.py
@@ -195,16 +195,19 @@ class DPT(nn.Module):
         feats[2] = self.conv_2(feats[2])
         feats[3] = self.conv_3(feats[3])
 
-        feats = [interpolate(x, scale_factor=2) for x in feats]
+        feats = [
+            interpolate(x, scale_factor=2, mode="bilinear", align_corners=True)
+            for x in feats
+        ]
 
         out = self.ref_3(feats[3], None)
         out = self.ref_2(feats[2], out)
         out = self.ref_1(feats[1], out)
         out = self.ref_0(feats[0], out)
 
-        out = interpolate(out, scale_factor=4)
+        out = interpolate(out, scale_factor=4, mode="bilinear", align_corners=True)
         out = self.out_conv(out)
-        out = interpolate(out, scale_factor=2)
+        out = interpolate(out, scale_factor=2, mode="bilinear", align_corners=True)
         return out
 
 
@@ -237,7 +240,7 @@ class Linear(nn.Module):
         if type(feats) is list:
             feats = torch.cat(feats, dim=1)
 
-        feats = interpolate(feats, scale_factor=4, mode="bilinear")
+        feats = interpolate(feats, scale_factor=4, mode="bilinear", align_corners=True)
         return self.conv(feats)
 
 
@@ -257,11 +260,14 @@ class MultiscaleHead(nn.Module):
         feats = [self.convs[i](feats[i]) for i in range(num_feats)]
 
         h, w = feats[-1].shape[-2:]
-        feats = [interpolate(feat, (h, w), mode="bilinear") for feat in feats]
+        feats = [
+            interpolate(feat, (h, w), mode="bilinear", align_corners=True)
+            for feat in feats
+        ]
         feats = torch.cat(feats, dim=1).relu()
 
         # upsample
-        feats = interpolate(feats, scale_factor=2, mode="bilinear")
+        feats = interpolate(feats, scale_factor=2, mode="bilinear", align_corners=True)
         feats = self.conv_mid(feats).relu()
-        feats = interpolate(feats, scale_factor=4, mode="bilinear")
+        feats = interpolate(feats, scale_factor=4, mode="bilinear", align_corners=True)
         return self.conv_out(feats)

--- a/train_snorm.py
+++ b/train_snorm.py
@@ -93,7 +93,9 @@ def train(
             else:
                 feats = model(images)
             pred = probe(feats)
-            pred = F.interpolate(pred, size=target.shape[-2:], mode="bicubic")
+            pred = F.interpolate(
+                pred, size=target.shape[-2:], mode="bicubic", align_corners=True
+            )
 
             uncertainty = pred.shape[1] > 3
             loss = angular_loss(pred, target, mask, uncertainty_aware=uncertainty)
@@ -130,7 +132,9 @@ def validate(model, probe, loader, verbose=True, aggregate=True):
 
             feats = model(images)
             pred = probe(feats)
-            pred = F.interpolate(pred, size=target.shape[-2:], mode="bicubic")
+            pred = F.interpolate(
+                pred, size=target.shape[-2:], mode="bicubic", align_corners=True
+            )
 
             uncertainty = pred.shape[1] > 3
             loss = angular_loss(pred, target, mask, uncertainty_aware=uncertainty)


### PR DESCRIPTION
### Summary
Switches the interpolation in the DPT head from nearest-neighbor to bilinear.  
Uses `align_corners=True, consistent with common practice in dense geometric tasks.

### Motivation
This change does not produce significant differences in quantitative performance,  
but it noticeably improves spatial smoothness in dense predictions.

### Notes
- No breaking changes.
- Matching behavior with typical depth/normal DPT architectures.
